### PR TITLE
修正字符集typo

### DIFF
--- a/gif2txt.py
+++ b/gif2txt.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# -*- coding: utf-8 -*-
 
 import argparse
 from PIL import Image


### PR DESCRIPTION
使用 `# coding=uft` 出现错误
环境：Python 3.6.1